### PR TITLE
fix(cli): add missing deps and change command path

### DIFF
--- a/.pnp.js
+++ b/.pnp.js
@@ -2620,6 +2620,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@arkecosystem/core-magistrate-crypto", "npm:3.0.0-next.4"],
             ["@arkecosystem/crypto", "npm:3.0.0-next.4"],
             ["@oclif/command", "virtual:94fac21a1a2025b70adfaefdf38827ffccf69dcfc9c3954fa9b39e3d15961f035ebaa812536ee9b164cb38c3f84cf0b130529ad59b30964af02dbc0d3619943e#npm:1.8.0"],
+            ["@oclif/errors", "npm:1.3.3"],
             ["@oclif/plugin-help", "npm:3.2.0"],
             ["@protokol/guardian-crypto", "npm:1.0.0-beta.28"],
             ["@protokol/nft-base-crypto", "npm:1.0.0-beta.28"],

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -26,20 +26,20 @@ protokol cli has 4 commands:
 To get general help use:
 
 ```bash
-./bin/run --help
+yarn node ./bin/run --help
 ```
 
 It is possible to get help for each subcommand
 
--   `./bin/run send --help`
--   `./bin/run send:transfer --help`
--   `./bin/run send:ipfs --help`
+-   `yarn node ./bin/run send --help`
+-   `yarn node ./bin/run send:transfer --help`
+-   `yarn node ./bin/run send:ipfs --help`
 -   ...
 
 For each subcommand check optional flags. Here is one run example
 
 ```bash
-./bin/run send:transfer -p="hurdle pulse sheriff anchor two hope income pattern hazard bacon book night" -q=2
+yarn node ./bin/run send:transfer -p="hurdle pulse sheriff anchor two hope income pattern hazard bacon book night" -q=2
 ```
 
 # Contact Us For Support And Custom Development

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -48,6 +48,7 @@
 		"@arkecosystem/core-magistrate-crypto": "^3.0.0-next.4",
 		"@arkecosystem/crypto": "^3.0.0-next.4",
 		"@oclif/command": "^1",
+		"@oclif/errors": "^1.3.3",
 		"@oclif/plugin-help": "^3",
 		"@protokol/guardian-crypto": "^1.0.0-beta.28",
 		"@protokol/nft-base-crypto": "^1.0.0-beta.28",
@@ -90,7 +91,7 @@
 		"typescript": "~4.0.2"
 	},
 	"oclif": {
-		"commands": "./src/commands",
+		"commands": "./dist/commands",
 		"bin": "proto-cli",
 		"topics": {
 			"send": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2376,6 +2376,7 @@ __metadata:
     "@arkecosystem/core-magistrate-crypto": ^3.0.0-next.4
     "@arkecosystem/crypto": ^3.0.0-next.4
     "@oclif/command": ^1
+    "@oclif/errors": ^1.3.3
     "@oclif/plugin-help": ^3
     "@protokol/guardian-crypto": ^1.0.0-beta.28
     "@protokol/nft-base-crypto": ^1.0.0-beta.28


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

### What changes are being made?
Added missing dependency and updated command path.

### Why are these changes necessary?
To make `cli` working again because it stopped working after migration to yarn berry.
Run command is now: `yarn node ./bin/run send:transfer`
Note that running `cli` throws an error but it is working and tx is sent to the network. This issue will be resolved later.

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->

