### PR TITLE
feat: allow sending transactions from/to non predefined wallets

### DIFF
--- a/packages/cli/src/commands/send/transfer.ts
+++ b/packages/cli/src/commands/send/transfer.ts
@@ -24,7 +24,7 @@ export default class Transfer extends SendBase {
 			mergedConfig.expiration = flags.expiration;
 		}
 		if (flags.recipientId) {
-			config.recipientId = flags.recipientId;
+			mergedConfig.recipientId = flags.recipientId;
 		}
 
 		return mergedConfig;

--- a/packages/cli/src/types/wallet.ts
+++ b/packages/cli/src/types/wallet.ts
@@ -1,6 +1,7 @@
 import { WalletSignType } from "../enums";
 
 export interface WalletChange {
+	passphrase?: string;
 	transaction: any;
 	address: string;
 	publicKey: string;

--- a/packages/cli/src/wallets-repository.ts
+++ b/packages/cli/src/wallets-repository.ts
@@ -34,16 +34,13 @@ export class WalletRepository {
 		this.wallets.push(wallet);
 	}
 
-	public getWallet(addressOrPassphrase: string): Wallet {
-		const wallet = this.wallets.find(
-			(x) => x.address === addressOrPassphrase || x.passphrase === addressOrPassphrase,
-		);
-
-		if (!wallet) {
-			throw new Error(`Wallet ${addressOrPassphrase} not found`);
-		}
-
-		return wallet;
+	public getWalletInfo(passphrase: string): Wallet {
+		return {
+			address: Identities.Address.fromPassphrase(passphrase),
+			passphrase,
+			publicKey: Identities.PublicKey.fromPassphrase(passphrase),
+			signType: WalletSignType.Basic,
+		};
 	}
 
 	public getRandomWallet(): Wallet {
@@ -57,7 +54,7 @@ export class WalletRepository {
 
 				if (response.data.accept.includes(id)) {
 					if (walletChange.secondPassphrase) {
-						const wallet = this.getWallet(walletChange.address);
+						const wallet = this.getWalletInfo(walletChange.passphrase!);
 
 						wallet.signType = WalletSignType.SecondSignature;
 						wallet.secondPassphrase = walletChange.secondPassphrase;


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

### What changes are being made?
Allow sending from/to wallets that are not defined in `wallets.json`

### Why are these changes necessary?
Right now it was only enabled to send transactions to/from wallets that are defined in `wallets.json`. This requires an unnecessary step to add a new wallet into `wallets.json` when `passphrase`/`recipientId` is provided using parameters.

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->

