### PR TITLE
fix(client): fix return type to array when returning multiple bids

### DIFF
--- a/.pnp.js
+++ b/.pnp.js
@@ -11150,7 +11150,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
       ]],
       ["ngrok", [
         ["npm:3.4.1", {
-          "packageLocation": "./.yarn/cache/ngrok-npm-3.4.1-fed079aa1a-aecf3201a0.zip/node_modules/ngrok/",
+          "packageLocation": "./.yarn/unplugged/ngrok-npm-3.4.1-fed079aa1a/node_modules/ngrok/",
           "packageDependencies": [
             ["ngrok", "npm:3.4.1"],
             ["@types/node", "npm:8.10.66"],
@@ -12748,7 +12748,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
       ]],
       ["protobufjs", [
         ["npm:6.10.2", {
-          "packageLocation": "./.yarn/cache/protobufjs-npm-6.10.2-f0f2cab7fe-09d6292362.zip/node_modules/protobufjs/",
+          "packageLocation": "./.yarn/unplugged/protobufjs-npm-6.10.2-f0f2cab7fe/node_modules/protobufjs/",
           "packageDependencies": [
             ["protobufjs", "npm:6.10.2"],
             ["@protobufjs/aspromise", "npm:1.1.2"],

--- a/packages/client/src/resources/nft/exchange/bids.ts
+++ b/packages/client/src/resources/nft/exchange/bids.ts
@@ -11,8 +11,8 @@ import {
 } from "../../../resources-types/nft/exchange";
 
 export class Bids extends Resource {
-	public async getAllBids(query?: AllBidsQuery): Promise<ApiResponseWithPagination<BidsResource>> {
-		return this.sendGet("nft/exchange/bids");
+	public async getAllBids(query?: AllBidsQuery): Promise<ApiResponseWithPagination<BidsResource[]>> {
+		return this.sendGet("nft/exchange/bids", query);
 	}
 
 	public async getBidById(id: string): Promise<ApiResponse<BidsResource>> {
@@ -30,8 +30,8 @@ export class Bids extends Resource {
 		return this.sendPost("nft/exchange/bids/search", payload, query);
 	}
 
-	public async getAllCanceledBids(query?: AllBidsCanceledQuery): Promise<ApiResponseWithPagination<BidCanceled>> {
-		return this.sendGet("nft/exchange/bids/canceled");
+	public async getAllCanceledBids(query?: AllBidsCanceledQuery): Promise<ApiResponseWithPagination<BidCanceled[]>> {
+		return this.sendGet("nft/exchange/bids/canceled", query);
 	}
 	public async getCanceledBidById(id: string): Promise<ApiResponse<BidCanceled>> {
 		return this.sendGet(`nft/exchange/bids/canceled/${id}`);

--- a/packages/client/src/resources/nft/exchange/trades.ts
+++ b/packages/client/src/resources/nft/exchange/trades.ts
@@ -10,7 +10,7 @@ import {
 
 export class Trades extends Resource {
 	public async all(query?: AllTradesQuery): Promise<ApiResponseWithPagination<TradesResource[]>> {
-		return this.sendGet("nft/exchange/trades");
+		return this.sendGet("nft/exchange/trades", query);
 	}
 
 	public async get(id: string): Promise<ApiResponse<TradeById>> {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

### What changes are being made?
Changed types for returning all bids and all canceled bids from single resource to array of resources.

### Why are these changes necessary?
To fix an error where the client suggests that getAllBids/getAllCanceledBids methods return a single resource instead of an array of resources.

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->

